### PR TITLE
fixed error in name of auth code grant flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
         <li><strong>Integration key:</strong> Any app you create with DocuSign is called an <em>integration.</em> All
           your integrations are identified in your DocuSign developer account by their <em>integration key,</em> which is a
           <a href="http://guid.one/guid" target="_blank" rel="nofollow noreferrer noopener">GUID</a> issued to your integration when you select <strong>Add App and Integration Key</strong> on the Apps and Keys page within your developer account’s Settings area. If you don't have any integrations in your developer account yet, select that button and give your integration a name. Use the Integration Key value, which is automatically generated when you click <strong>OK.</strong></li>
-        <li><strong>Corresponding secret key:</strong> For <a href="https://developers.docusign.com/platform/auth/authcode/" target="_blank" rel="noopener nofollow noreferrer">Authentication Code Grant authentication</a>, your integration
+        <li><strong>Corresponding secret key:</strong> For <a href="https://developers.docusign.com/platform/auth/authcode/" target="_blank" rel="noopener nofollow noreferrer">Authorization Code Grant authentication</a>, your integration
           needs a secret key as well. Select <strong>Add Secret Key</strong> on the Apps and Keys page and copy the value; you can only do
           this when you create the key, as it won't be visible thereafter.</li>
         <li><strong>Environment:</strong> Choose Demo.</li>


### PR DESCRIPTION
In the HTML page, fixed one instance of authorization code grant being erroneously referred to as "authentication code grant."