### PR TITLE
FIX: Fix the large file sending issue in github actions

### DIFF
--- a/.github/workflows/sync-admin.yml
+++ b/.github/workflows/sync-admin.yml
@@ -24,7 +24,14 @@ jobs:
         GITHUB_COLLECTION_PATH="./assets/admin-collection.json"
         COLLECTION_UID=${{ vars.ADMIN_COLLECTION_UID }}
         
+        # Read the file content and wrap it inside a collection object
+        WRAPPED_CONTENT=$(jq -n --argfile data "$GITHUB_COLLECTION_PATH" '{"collection": $data}')
+        
+        # Write the wrapped content to a temporary file
+        echo "$WRAPPED_CONTENT" > wrapped_collection.json
+        
+        # Use curl with --data-binary to handle large file content
         curl --location --request PUT "https://api.getpostman.com/collections/$COLLECTION_UID" \
-        --header "x-api-key: $POSTMAN_API_KEY" \
-        --header "Content-Type: application/json" \
-        --data "{\"collection\": $(cat $GITHUB_COLLECTION_PATH)}"
+             --header "x-api-key: $POSTMAN_API_KEY" \
+             --header "Content-Type: application/json" \
+             --data-binary @wrapped_collection.json

--- a/.github/workflows/sync-admin.yml
+++ b/.github/workflows/sync-admin.yml
@@ -3,7 +3,7 @@ name: Sync Admin Postman Collection
 on:
   push:
     branches:
-      - main  # Change this to the branch you want to trigger the action
+      - master  # Change this to the branch you want to trigger the action
     paths:
       - 'assets/admin-collection.json'
 

--- a/.github/workflows/sync-click.yml
+++ b/.github/workflows/sync-click.yml
@@ -24,7 +24,14 @@ jobs:
         GITHUB_COLLECTION_PATH="./assets/click-collection.json"
         COLLECTION_UID=${{ vars.CLICK_COLLECTION_UID }}
         
+        # Read the file content and wrap it inside a collection object
+        WRAPPED_CONTENT=$(jq -n --argfile data "$GITHUB_COLLECTION_PATH" '{"collection": $data}')
+        
+        # Write the wrapped content to a temporary file
+        echo "$WRAPPED_CONTENT" > wrapped_collection.json
+        
+        # Use curl with --data-binary to handle large file content
         curl --location --request PUT "https://api.getpostman.com/collections/$COLLECTION_UID" \
-        --header "x-api-key: $POSTMAN_API_KEY" \
-        --header "Content-Type: application/json" \
-        --data "{\"collection\": $(cat $GITHUB_COLLECTION_PATH)}"
+             --header "x-api-key: $POSTMAN_API_KEY" \
+             --header "Content-Type: application/json" \
+             --data-binary @wrapped_collection.json

--- a/.github/workflows/sync-click.yml
+++ b/.github/workflows/sync-click.yml
@@ -3,7 +3,7 @@ name: Sync Click Postman Collection
 on:
   push:
     branches:
-      - main  # Change this to the branch you want to trigger the action
+      - master  # Change this to the branch you want to trigger the action
     paths:
       - 'assets/click-collection.json'
 

--- a/.github/workflows/sync-esign-v2.1.yml
+++ b/.github/workflows/sync-esign-v2.1.yml
@@ -24,7 +24,14 @@ jobs:
         GITHUB_COLLECTION_PATH="./assets/esign-v2.1-collection.json"
         COLLECTION_UID=${{ vars.ESIGN_COLLECTION_UID }}
         
+        # Read the file content and wrap it inside a collection object
+        WRAPPED_CONTENT=$(jq -n --argfile data "$GITHUB_COLLECTION_PATH" '{"collection": $data}')
+        
+        # Write the wrapped content to a temporary file
+        echo "$WRAPPED_CONTENT" > wrapped_collection.json
+        
+        # Use curl with --data-binary to handle large file content
         curl --location --request PUT "https://api.getpostman.com/collections/$COLLECTION_UID" \
-        --header "x-api-key: $POSTMAN_API_KEY" \
-        --header "Content-Type: application/json" \
-        --data "{\"collection\": $(cat $GITHUB_COLLECTION_PATH)}"
+             --header "x-api-key: $POSTMAN_API_KEY" \
+             --header "Content-Type: application/json" \
+             --data-binary @wrapped_collection.json

--- a/.github/workflows/sync-esign-v2.1.yml
+++ b/.github/workflows/sync-esign-v2.1.yml
@@ -3,7 +3,7 @@ name: Sync ESign-V2.1 Postman Collection
 on:
   push:
     branches:
-      - main  # Change this to the branch you want to trigger the action
+      - master  # Change this to the branch you want to trigger the action
     paths:
       - 'assets/esign-v2.1-collection.json'
 

--- a/.github/workflows/sync-maestro.yml
+++ b/.github/workflows/sync-maestro.yml
@@ -24,7 +24,14 @@ jobs:
         GITHUB_COLLECTION_PATH="./assets/maestro-collection.json"
         COLLECTION_UID=${{ vars.MAESTRO_COLLECTION_UID }}
         
+        # Read the file content and wrap it inside a collection object
+        WRAPPED_CONTENT=$(jq -n --argfile data "$GITHUB_COLLECTION_PATH" '{"collection": $data}')
+        
+        # Write the wrapped content to a temporary file
+        echo "$WRAPPED_CONTENT" > wrapped_collection.json
+        
+        # Use curl with --data-binary to handle large file content
         curl --location --request PUT "https://api.getpostman.com/collections/$COLLECTION_UID" \
-        --header "x-api-key: $POSTMAN_API_KEY" \
-        --header "Content-Type: application/json" \
-        --data "{\"collection\": $(cat $GITHUB_COLLECTION_PATH)}"
+             --header "x-api-key: $POSTMAN_API_KEY" \
+             --header "Content-Type: application/json" \
+             --data-binary @wrapped_collection.json

--- a/.github/workflows/sync-maestro.yml
+++ b/.github/workflows/sync-maestro.yml
@@ -3,7 +3,7 @@ name: Sync Maestro Postman Collection
 on:
   push:
     branches:
-      - main  # Change this to the branch you want to trigger the action
+      - master  # Change this to the branch you want to trigger the action
     paths:
       - 'assets/maestro-collection.json'
 

--- a/.github/workflows/sync-monitor.yml
+++ b/.github/workflows/sync-monitor.yml
@@ -24,7 +24,14 @@ jobs:
         GITHUB_COLLECTION_PATH="./assets/monitor-collection.json"
         COLLECTION_UID=${{ vars.MONITOR_COLLECTION_UID }}
         
+        # Read the file content and wrap it inside a collection object
+        WRAPPED_CONTENT=$(jq -n --argfile data "$GITHUB_COLLECTION_PATH" '{"collection": $data}')
+        
+        # Write the wrapped content to a temporary file
+        echo "$WRAPPED_CONTENT" > wrapped_collection.json
+        
+        # Use curl with --data-binary to handle large file content
         curl --location --request PUT "https://api.getpostman.com/collections/$COLLECTION_UID" \
-        --header "x-api-key: $POSTMAN_API_KEY" \
-        --header "Content-Type: application/json" \
-        --data "{\"collection\": $(cat $GITHUB_COLLECTION_PATH)}"
+             --header "x-api-key: $POSTMAN_API_KEY" \
+             --header "Content-Type: application/json" \
+             --data-binary @wrapped_collection.json

--- a/.github/workflows/sync-monitor.yml
+++ b/.github/workflows/sync-monitor.yml
@@ -3,7 +3,7 @@ name: Sync Monitor Postman Collection
 on:
   push:
     branches:
-      - main  # Change this to the branch you want to trigger the action
+      - master  # Change this to the branch you want to trigger the action
     paths:
       - 'assets/monitor-collection.json'
 

--- a/.github/workflows/sync-rooms.yml
+++ b/.github/workflows/sync-rooms.yml
@@ -3,7 +3,7 @@ name: Sync Rooms Postman Collection
 on:
   push:
     branches:
-      - main  # Change this to the branch you want to trigger the action
+      - master  # Change this to the branch you want to trigger the action
     paths:
       - 'assets/rooms-collection.json'
 

--- a/.github/workflows/sync-rooms.yml
+++ b/.github/workflows/sync-rooms.yml
@@ -24,7 +24,14 @@ jobs:
         GITHUB_COLLECTION_PATH="./assets/rooms-collection.json"
         COLLECTION_UID=${{ vars.ROOMS_COLLECTION_UID }}
         
+        # Read the file content and wrap it inside a collection object
+        WRAPPED_CONTENT=$(jq -n --argfile data "$GITHUB_COLLECTION_PATH" '{"collection": $data}')
+        
+        # Write the wrapped content to a temporary file
+        echo "$WRAPPED_CONTENT" > wrapped_collection.json
+        
+        # Use curl with --data-binary to handle large file content
         curl --location --request PUT "https://api.getpostman.com/collections/$COLLECTION_UID" \
-        --header "x-api-key: $POSTMAN_API_KEY" \
-        --header "Content-Type: application/json" \
-        --data "{\"collection\": $(cat $GITHUB_COLLECTION_PATH)}"
+             --header "x-api-key: $POSTMAN_API_KEY" \
+             --header "Content-Type: application/json" \
+             --data-binary @wrapped_collection.json

--- a/.github/workflows/sync-webforms.yml
+++ b/.github/workflows/sync-webforms.yml
@@ -24,7 +24,14 @@ jobs:
         GITHUB_COLLECTION_PATH="./assets/webforms-collection.json"
         COLLECTION_UID=${{ vars.WEBFORMS_COLLECTION_UID }}
         
+        # Read the file content and wrap it inside a collection object
+        WRAPPED_CONTENT=$(jq -n --argfile data "$GITHUB_COLLECTION_PATH" '{"collection": $data}')
+        
+        # Write the wrapped content to a temporary file
+        echo "$WRAPPED_CONTENT" > wrapped_collection.json
+        
+        # Use curl with --data-binary to handle large file content
         curl --location --request PUT "https://api.getpostman.com/collections/$COLLECTION_UID" \
-        --header "x-api-key: $POSTMAN_API_KEY" \
-        --header "Content-Type: application/json" \
-        --data "{\"collection\": $(cat $GITHUB_COLLECTION_PATH)}"
+             --header "x-api-key: $POSTMAN_API_KEY" \
+             --header "Content-Type: application/json" \
+             --data-binary @wrapped_collection.json

--- a/.github/workflows/sync-webforms.yml
+++ b/.github/workflows/sync-webforms.yml
@@ -3,7 +3,7 @@ name: Sync Webforms Postman Collection
 on:
   push:
     branches:
-      - main  # Change this to the branch you want to trigger the action
+      - master  # Change this to the branch you want to trigger the action
     paths:
       - 'assets/webforms-collection.json'
 


### PR DESCRIPTION
The larger data were not being sent to Postman. 
FIX: Sending the large data by converting it in binary