### PR TITLE
Add sync workflow for Connected Fields Postman collection

### DIFF
--- a/.github/workflows/sync-connected-fields.yml
+++ b/.github/workflows/sync-connected-fields.yml
@@ -1,0 +1,19 @@
+name: Sync Connected Fields Postman Collection
+
+on:
+  push:
+    branches:
+      - master  # Change this to the branch you want to trigger the action
+    paths:
+      - 'assets/connected-fields-collection.json'
+
+  workflow_dispatch:  # Enables manual trigger from GitHub UI
+
+jobs:
+  sync-postman-collection:
+    uses: ./.github/workflows/sync-postman-collection.yml
+    with:
+      collection-uid: ${{ vars.CONNECTED_FIELDS_COLLECTION_UID }}
+      collection-path: './assets/connected-fields-collection.json'
+    secrets:
+      POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`sync-connected-fields.yml`) to sync the Connected Fields Postman collection to the Postman platform
- Follows the same reusable workflow pattern as other API families (Navigator, Maestro, etc.)

## Prerequisites before merging
- [ ] Add `CONNECTED_FIELDS_COLLECTION_UID` variable in repo Settings → Variables
- [ ] Ensure `assets/connected-fields-collection.json` is generated and committed

## Test plan
- [ ] Verify workflow syntax is valid via GitHub Actions tab
- [ ] After adding the collection UID variable, trigger manually via `workflow_dispatch` to confirm sync works

🤖 Generated with [Claude Code](https://claude.com/claude-code)